### PR TITLE
Parse HTML into text and title

### DIFF
--- a/newspeek/pom.xml
+++ b/newspeek/pom.xml
@@ -134,6 +134,12 @@
             <artifactId>dotenv-java</artifactId>
             <version>3.0.0</version>
         </dependency>
+        <dependency>
+            <!-- jsoup HTML parser library @ https://jsoup.org/ -->
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.18.1</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/newspeek/src/main/java/data_access/APIDataAccessObject.java
+++ b/newspeek/src/main/java/data_access/APIDataAccessObject.java
@@ -13,9 +13,7 @@ import java.net.MalformedURLException;
 import java.net.URLConnection;
 import java.net.URL;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Objects;
-import java.util.Random;
+import java.util.*;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -49,15 +47,24 @@ public class APIDataAccessObject implements RandomArticleAPIDataAccessInterface 
 
     @Override
     public Article getRandomArticle(String country) throws java.io.IOException, NewsAPIException {
-        String url = getRandomURL(country);
-        return this.scraper.scrapeArticle(url);
+        AbstractList<String> urls = getTopURLs(country);
+        Collections.shuffle(urls);
+
+        for (String url : urls) {
+            try {
+                return this.scraper.scrapeArticle(url);
+            } catch (IOException ignored) {
+                // continue through the articles
+            }
+        }
+        throw new NewsAPIException("All returned articles couldn't be scraped.");
     }
 
     public Article getArticleFromURL(String url) throws IOException {
         return this.scraper.scrapeArticle(url);
     }
 
-    private String getRandomURL(String country) throws java.io.IOException, NewsAPIException {
+    private AbstractList<String> getTopURLs(String country) throws java.io.IOException, NewsAPIException {
         String url = API_ENDPOINT_RANDOM +
                 "?country=" +
                 country +
@@ -83,8 +90,7 @@ public class APIDataAccessObject implements RandomArticleAPIDataAccessInterface 
             urls.add(article.getAsJsonObject().get("url").getAsString());
         }
 
-        // Return a random one
-        return urls.get(new Random().nextInt(urls.size()));
+        return urls;
     }
 
     private JsonObject get(String urlString) throws java.io.IOException {

--- a/newspeek/src/main/java/use_case/helpers/JReadabilityScraper.java
+++ b/newspeek/src/main/java/use_case/helpers/JReadabilityScraper.java
@@ -32,7 +32,13 @@ public class JReadabilityScraper implements Scraper {
 
             readability.init();
 
-            return scrapeFromCleanHTML(readability.outerHtml(), url);
+            final String cleanHTML = readability.outerHtml();
+
+            if (cleanHTML.contains("Sorry, readability was unable to parse this page for content.")) {
+                throw new IOException("JReadabilityScraper: couldn't scrape");
+            }
+
+            return scrapeFromCleanHTML(cleanHTML, url);
         } catch (MalformedURLException e) {
             System.err.println("JReadabilityScraper: Unrecoverable error: malformed URL.");
             e.printStackTrace();

--- a/newspeek/src/main/java/use_case/helpers/JReadabilityScraper.java
+++ b/newspeek/src/main/java/use_case/helpers/JReadabilityScraper.java
@@ -8,6 +8,11 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.LocalDateTime;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.safety.Safelist;
+import org.jsoup.select.Elements;
 
 public class JReadabilityScraper implements Scraper {
     private static final int TIMEOUT_MS = 10_000;
@@ -27,14 +32,7 @@ public class JReadabilityScraper implements Scraper {
 
             readability.init();
 
-            final String text = readability.outerHtml();
-
-            final String title = "Unknown title";
-            final String author = "Unknown author";
-            final String agency = "Unknown agency";
-            final LocalDateTime postedAt = LocalDateTime.now();
-
-            return this.articleFactory.create(title, text, url, author, agency, postedAt);
+            return scrapeFromCleanHTML(readability.outerHtml(), url);
         } catch (MalformedURLException e) {
             System.err.println("JReadabilityScraper: Unrecoverable error: malformed URL.");
             e.printStackTrace();
@@ -42,5 +40,25 @@ public class JReadabilityScraper implements Scraper {
         }
         /* unreachable */
         return null;
+    }
+
+    private Article scrapeFromCleanHTML(String html, String url) {
+        Document doc = Jsoup.parse(html);
+        Elements paragraphs = doc.select("p");
+        Elements titles = doc.select("h1");
+
+        // Append the paragraphs into a single string
+        StringBuilder textBuilder = new StringBuilder();
+        for (Element paragraph : paragraphs) {
+            textBuilder.append(paragraph.text()).append("\n");
+        }
+
+        final String title = titles.get(0).text();
+        final String text = textBuilder.toString();
+        final String author = "Unknown author";
+        final String agency = "Unknown agency";
+        final LocalDateTime postedAt = LocalDateTime.now();
+
+        return this.articleFactory.create(title, text, url, author, agency, postedAt);
     }
 }


### PR DESCRIPTION
Articles returned by `APIDataAccessObject.randomArticle()` now have only plaintext in the `Article.text` attribute, and a correct title in `Article.title`. The author, agency, and posting time are still placeholders. Nonetheless, this should be good enough for our MVP if we add a title display to the `ReaderView`